### PR TITLE
Ignore coverage files for external libraries

### DIFF
--- a/source/doveralls/sourcefiles.d
+++ b/source/doveralls/sourcefiles.d
@@ -13,6 +13,9 @@ JSONValue[] getSourceFiles(string path)
 
     foreach (string lstPath; dirEntries(path, "*.lst", SpanMode.breadth, true))
     {
+        if (lstPath.baseName.startsWith(".."))
+            continue;
+
         string relPath;
         foreach (line; File(lstPath).byLine(KeepTerminator.no))
         {


### PR DESCRIPTION
This fixes #17 by ignoring the lst files which start with `..`.