### PR TITLE
Travis overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
+sudo: false
 language: d
 d:
 - dmd
 - ldc
-- gdc
 os:
 - linux
 - osx
-matrix:
-  exclude:
-  - os: osx
-    d: gdc
-sudo: false
+
+script:
+- dub test --compiler=${DC}
+
 after_success:
-- dub build --compiler=${DC}
+- dub run
 - cp doveralls doveralls_${TRAVIS_OS_NAME}_travis
+
 deploy:
   provider: releases
   api_key:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## doveralls [![Build Status](https://img.shields.io/travis/ColdenCullen/doveralls.svg?style=flat)](https://travis-ci.org/ColdenCullen/doveralls)
+## doveralls [![Build Status](https://img.shields.io/travis/ColdenCullen/doveralls.svg?style=flat)](https://travis-ci.org/ColdenCullen/doveralls) [![Coverage Status](https://coveralls.io/repos/github/ColdenCullen/doveralls/badge.svg?branch=master)](https://coveralls.io/github/ColdenCullen/doveralls?branch=master)
 
 Upload D code coverage results to [coveralls.io](https://coveralls.io/).
 


### PR DESCRIPTION
* Remove GDC support, since the compilers are suuuper old (2016?)
* Actually publish test results to coveralls